### PR TITLE
add toc_depth option

### DIFF
--- a/R/readthedown.R
+++ b/R/readthedown.R
@@ -13,6 +13,7 @@
 #' @param thumbnails if TRUE display content images as thumbnails
 #' @param gallery if TRUE and lightbox is TRUE, add a gallery navigation between images in lightbox display
 #' @param pandoc_args arguments passed to the pandoc_args argument of rmarkdown \code{\link{html_document}}
+#' @param toc_depth adjust topic depth for banner
 #' @param ... Additional function arguments passed to R Markdown \code{\link{html_document}}
 #' @return R Markdown output format to pass to \code{\link{render}}
 #' @import rmarkdown
@@ -28,6 +29,7 @@ readthedown <- function(fig_width = 8,
                        thumbnails = FALSE,
                        gallery = FALSE,
                        pandoc_args = NULL,
+                       toc_depth = 3,
                        ...) {
  
   ## js and css dependencies
@@ -57,7 +59,7 @@ readthedown <- function(fig_width = 8,
       highlight = highlight,
       pandoc_args = pandoc_args,
       toc = TRUE,
-      toc_depth = 2,
+      toc_depth = toc_depth,
       ...
     )
       


### PR DESCRIPTION
**add `toc_depth` attributes of `readthedown()` function**

I am a Korean (*Please note that do not speak English well.*) & basic R user who favored the rmdformats package of R.
I really thank you for providing the package.
By the way, today I wish to adjust style the readthedown output.
I want topic depth 3 more [like this](https://www.dropbox.com/s/cs9b69a7wvqgi36/MySql_Study.html?dl=0).
but I don't know about adjust tocpic depth easily.
So I tried to modify the code. 

Try the first pull request from Github.
Thank you for reading the article.