### PR TITLE
added toc_depth to material function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,5 +17,5 @@ Imports:
     htmltools,
     questionr
 URL: https://github.com/juba/rmdformats
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 VignetteBuilder: knitr

--- a/R/material.R
+++ b/R/material.R
@@ -85,7 +85,7 @@ material <- function(fig_width = 6,
     highlight = highlight,
     pandoc_args = pandoc_args,
     toc = TRUE,
-    toc_depth = toc_depth,
+    toc_depth = toc_depth
   )
   html_document_args <- append(html_document_args, extra_args)
   if (use_bookdown) {

--- a/R/material.R
+++ b/R/material.R
@@ -20,6 +20,7 @@
 #' @param pandoc_args arguments passed to the pandoc_args argument of rmarkdown \code{\link[rmarkdown]{html_document}}
 #' @param use_bookdown if TRUE, uses \code{\link[bookdown]{html_document2}} instead of \code{\link[rmarkdown]{html_document}}, thus providing numbered sections and cross references
 #' @param mathjax set to NULL to disable Mathjax insertion
+#' @param toc_depth adjust TOC depth
 #' @param ... Additional function arguments passed to R Markdown \code{\link[rmarkdown]{html_document}}
 #' @return R Markdown output format to pass to \code{\link[rmarkdown]{render}}
 #' @import rmarkdown
@@ -39,6 +40,7 @@ material <- function(fig_width = 6,
                      mathjax = "rmdformats",
                      pandoc_args = NULL,
                      use_bookdown = FALSE,
+                     toc_depth = 1,
                      ...) {
 
   ## js and css dependencies
@@ -83,7 +85,7 @@ material <- function(fig_width = 6,
     highlight = highlight,
     pandoc_args = pandoc_args,
     toc = TRUE,
-    toc_depth = 1
+    toc_depth = toc_depth,
   )
   html_document_args <- append(html_document_args, extra_args)
   if (use_bookdown) {

--- a/man/material.Rd
+++ b/man/material.Rd
@@ -7,7 +7,7 @@
 material(fig_width = 6, fig_height = 6, fig_caption = TRUE,
   highlight = "kate", lightbox = TRUE, thumbnails = TRUE,
   gallery = FALSE, cards = TRUE, mathjax = "rmdformats",
-  pandoc_args = NULL, use_bookdown = FALSE, ...)
+  pandoc_args = NULL, use_bookdown = FALSE, toc_depth = 1, ...)
 }
 \arguments{
 \item{fig_width}{Default width (in inches) for figures}
@@ -34,6 +34,8 @@ highlighting.}
 \item{pandoc_args}{arguments passed to the pandoc_args argument of rmarkdown \code{\link[rmarkdown]{html_document}}}
 
 \item{use_bookdown}{if TRUE, uses \code{\link[bookdown]{html_document2}} instead of \code{\link[rmarkdown]{html_document}}, thus providing numbered sections and cross references}
+
+\item{toc_depth}{adjust TOC depth}
 
 \item{...}{Additional function arguments passed to R Markdown \code{\link[rmarkdown]{html_document}}}
 }


### PR DESCRIPTION
Following the pattern in the prior pull request for adding `toc_depth` to `readthedown` (https://github.com/juba/rmdformats/pull/12/commits/3631afa6613def8e50f5e7d2a5ba5f93050ed39c), I've added the same thing for `material`. I rebuilt documentation using roxygen, so I hope this is a pretty simple PR. 

Thank you for your great work with this project. It makes fantastic documents. Much appreciated. 