### PR TITLE
Map tiles appear in lightbox gallery

### DIFF
--- a/inst/templates/template.html
+++ b/inst/templates/template.html
@@ -435,7 +435,7 @@ $endif$
 	    type:'image',
 	    closeOnContentClick: false,
 	    closeBtnInside: false,
-	    delegate: 'img',
+	    delegate: '.image-lb',
 	    gallery: {enabled: $gallery$ },
 	    image: {
 	        verticalFit: true,


### PR DESCRIPTION
### Issue

I was using the `html_clean` template to compile a report with images and also a map, and noticed that the map tiles were appearing in the image gallery alongside my images and plots.

![image](https://user-images.githubusercontent.com/46049880/102215332-7a8bc780-3ed1-11eb-9d12-aeb9ad338cc9.png)

### Fix 

This PR changes `template.html`, which was using `img` as delegate for gallery items, to use the lightbox class `.image-lb` as delegate instead, thus using only images which can be directly opened in a lightbox in the gallery. This seems to be more desirable behaviour for the gallery view.

### MWE

The code below generates a simple `html_clean` report containing a plot (to appear in the gallery) and a map (whose tiles should not appear in the gallery).

````
---
title: "Gallery Demo"
date: "`r Sys.Date()`"
output:
  rmdformats::html_clean:
    highlight: kate
    lightbox: true
    gallery: true
---


```{r setup, include=FALSE}
library(knitr)
library(rmdformats)
library(leaflet)

## Global options
options(max.print="75")
opts_chunk$set(echo=FALSE,
	             cache=TRUE,
               prompt=FALSE,
               tidy=TRUE,
               comment=NA,
               message=FALSE,
               warning=FALSE)
opts_knit$set(width=75)
```

```{r plot}
plot(mpg ~ cyl, mtcars)
```

```{r map}
leaflet(padding = 10) %>% addTiles()
```

````
