### PR TITLE
readthedown CSS tidy up

### DIFF
--- a/inst/templates/readthedown/readthedown.css
+++ b/inst/templates/readthedown/readthedown.css
@@ -163,7 +163,6 @@ body{
     background:#fcfcfc;
     height:100%;
     margin-left:300px;
-    /* margin:auto; */
     max-width:900px;
     min-height:100%;
 }
@@ -193,7 +192,6 @@ blockquote{
     font-style:italic;
     line-height:24px;
     margin:0px 0px 24px 0px;
-    /* margin-left:24px; */
     padding: 6px 20px;
 }
 #content blockquote > p,
@@ -204,7 +202,6 @@ blockquote{
 ul,ol,dl{
     line-height:24px;
     list-style-image:none;
-    /* list-style:none; */
     margin:0px 0px 24px 0px;
     padding:0;
 }
@@ -432,7 +429,6 @@ dl dd{
 code{
     background:#fff;
     border:solid 1px #e1e4e5;
-    /* color:#000;  for clickable code */
     font-size:85%;
     max-width:100%;
     overflow-x:auto;
@@ -454,9 +450,7 @@ code{
 }
 
 #content pre {
-    /* background:#f3f6f6; */
     border:1px solid #e1e4e5;
-    /* color:#404040; */
     line-height: 1.5;
     margin-bottom:24px;
     overflow:auto;
@@ -467,7 +461,6 @@ code{
 }
 
 #content pre.sourceCode{
-    /* background-color: #FFF; */
     margin:1px 0px 12px 0px;
 }
 
@@ -620,7 +613,6 @@ legend{
     padding:12px;
     line-height:24px;
     margin-bottom:24px;
-    /* background:#e7f2fa; */
 }
 
 .wy-alert-title,#content .admonition-title{
@@ -628,8 +620,6 @@ legend{
     font-weight:bold;
     display:block;
     color:#fff;
-    /* background:#6ab0de; */
-    /* margin:-12px; */
     padding:6px 12px;
     margin-bottom:0px}
 
@@ -772,19 +762,14 @@ hr{
     background:#d6d6d6}
 
 #toc li a{
-    /* color:#404040; */
     padding:0.4045em 1.618em;
     position:relative;
-    /* background:#fcfcfc; */
     border:none;}
-    /* border-bottom:solid 1px #c9c9c9; */
-    /* border-top:solid 1px #c9c9c9; */
 
 #toc li.on a:hover,#toc li.current>a:hover{
     background:#fcfcfc}
 
 #toc li ul li a{
-    /* background:#c9c9c9; */
     padding:0.4045em 2.427em}
 
 #toc li ul li ul li a{
@@ -909,14 +894,9 @@ hr{
     display: none !important;
 }
 
-/* ul.nav li ul li ul li { */
-/*     display: none !important; /\* as long as nav is on multiple levels of ul *\/ */
-/*     /\* display: none; /\* as long as nav is on multiple levels of ul *\\/ *\/ */
-/* } */
 
 #toc ul.nav li ul li ul li ul li {
     display: none !important; /* as long as nav is on multiple levels of ul */
-    /* display: none; /* as long as nav is on multiple levels of ul *\/ */
 }
 
 #toc ul.nav li.active > a {
@@ -1074,7 +1054,6 @@ h2.footnotes{
     padding-right: 16px;
     padding-top: 8px;
     line-height: 1.25em;
-    /* display: inline; */
 }
 
 /* Code folding buttons */

--- a/inst/templates/readthedown/readthedown.css
+++ b/inst/templates/readthedown/readthedown.css
@@ -619,7 +619,6 @@ legend{
     color:#fff;
     font-weight:bold;
     display:block;
-    color:#fff;
     padding:6px 12px;
     margin-bottom:0px}
 

--- a/inst/templates/readthedown/readthedown.css
+++ b/inst/templates/readthedown/readthedown.css
@@ -777,10 +777,9 @@ hr{
     padding:0.4045em 1.618em;
     position:relative;
     /* background:#fcfcfc; */
-    border:none;
+    border:none;}
     /* border-bottom:solid 1px #c9c9c9; */
     /* border-top:solid 1px #c9c9c9; */
-    padding-left:1.618em -4px}
 
 #toc li.on a:hover,#toc li.current>a:hover{
     background:#fcfcfc}

--- a/inst/templates/readthedown/readthedown.css
+++ b/inst/templates/readthedown/readthedown.css
@@ -745,7 +745,6 @@ hr{
     display:inline-block;
     line-height:32px;
     padding:0 1.618em;
-    display:block;
     font-weight:bold;
     text-transform:uppercase;
     font-size:80%;

--- a/inst/templates/readthedown/readthedown.css
+++ b/inst/templates/readthedown/readthedown.css
@@ -806,7 +806,6 @@ hr{
     display:inline-block;
     line-height:18px;
     padding:0.4045em 1.618em;
-    display:block;
     position:relative;
     font-size:90%;
     color:#b3b3b3;


### PR DESCRIPTION
None of these are important and the diff should have no functional impact. They are just clean up suggestions. Most of the diff is just in removing code that had all be commented out. The lines which were not commented out were all some version of duplicated directive within a single selector. 

For the two selectors that had both `display:inline-block;` and `display:block;` within them I picked `display:inline-block;` because that was the active rule when I checked in dev tools in FF and Chrome. That said I couldn't find any clear spec for what is supposed to happen when a directive is redeclared within a selector so I am not 100% sure that this edit is a silent change in all rendering engines. 